### PR TITLE
feat: Add team data for 2022, 2023, and 2024 with LinkedIn integration

### DIFF
--- a/scripts/addLinkedIn.js
+++ b/scripts/addLinkedIn.js
@@ -1,0 +1,93 @@
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+const TEAM_DATA_DIR = path.join(process.cwd(), 'data/team');
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+function askQuestion(question) {
+  return new Promise(resolve => {
+    rl.question(question, answer => {
+      resolve(answer);
+    });
+  });
+}
+
+async function addLinkedInUrls(year) {
+  const dataFilePath = path.join(TEAM_DATA_DIR, `${year}.json`);
+  
+  if (!fs.existsSync(dataFilePath)) {
+    console.log(`❌ Arquivo ${year}.json não encontrado`);
+    return;
+  }
+
+  const teamData = JSON.parse(fs.readFileSync(dataFilePath, 'utf8'));
+  let hasChanges = false;
+
+  console.log(`🔗 Adicionando URLs do LinkedIn para o ano ${year}\n`);
+
+  for (const [category, members] of Object.entries(teamData)) {
+    console.log(`📁 Categoria: ${category}`);
+    
+    for (let i = 0; i < members.length; i++) {
+      const member = members[i];
+      
+      if (!member.linkedin || member.linkedin === '') {
+        console.log(`\n👤 Membro: ${member.name}`);
+        const linkedinUrl = await askQuestion('   LinkedIn URL (Enter para pular): ');
+        
+        if (linkedinUrl.trim() !== '') {
+          member.linkedin = linkedinUrl.trim();
+          hasChanges = true;
+          console.log('   ✅ LinkedIn adicionado!');
+        } else {
+          console.log('   ⏭️  Pulado');
+        }
+      } else {
+        console.log(`   ✅ ${member.name} - LinkedIn já definido`);
+      }
+    }
+  }
+
+  if (hasChanges) {
+    fs.writeFileSync(dataFilePath, JSON.stringify(teamData, null, 2));
+    console.log(`\n🎉 Dados salvos em ${year}.json`);
+  } else {
+    console.log(`\n📝 Nenhuma alteração feita`);
+  }
+}
+
+async function main() {
+  console.log('🚀 Ferramenta para adicionar URLs do LinkedIn\n');
+  
+  // Lista anos disponíveis
+  const years = fs.readdirSync(TEAM_DATA_DIR)
+    .filter(file => file.endsWith('.json'))
+    .map(file => file.replace('.json', ''))
+    .sort();
+  
+  if (years.length === 0) {
+    console.log('❌ Nenhum arquivo de dados da equipe encontrado');
+    rl.close();
+    return;
+  }
+  
+  console.log(`📅 Anos disponíveis: ${years.join(', ')}`);
+  
+  const selectedYear = await askQuestion('Qual ano você quer editar? ');
+  
+  if (!years.includes(selectedYear)) {
+    console.log('❌ Ano inválido');
+    rl.close();
+    return;
+  }
+  
+  await addLinkedInUrls(selectedYear);
+  rl.close();
+}
+
+main().catch(console.error);

--- a/scripts/generateTeamData.js
+++ b/scripts/generateTeamData.js
@@ -1,0 +1,143 @@
+const fs = require('fs');
+const path = require('path');
+
+const TEAM_DIR = path.join(process.cwd(), 'public/images/team');
+const TEAM_DATA_DIR = path.join(process.cwd(), 'data/team');
+
+function normalizeImageName(imageName) {
+  // Remove a extensão .webp ou .png
+  const baseName = imageName.replace(/\.(webp|png)$/i, '');
+  
+  // Remove números e hífens do início (ex: "1 - " ou "2 - ")
+  const cleanName = baseName.replace(/^\d+\s*-\s*/, '');
+  
+  // Converte underscores para espaços e capitaliza cada palavra
+  return cleanName
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, letter => letter.toUpperCase());
+}
+
+function generateTeamDataForYear(year) {
+  const yearPath = path.join(TEAM_DIR, year);
+  const dataFilePath = path.join(TEAM_DATA_DIR, `${year}.json`);
+  
+  if (!fs.existsSync(yearPath)) {
+    console.log(`⚠️  Diretório para o ano ${year} não existe`);
+    return;
+  }
+
+  // Lê dados existentes para preservar LinkedIn URLs
+  let existingData = {};
+  if (fs.existsSync(dataFilePath)) {
+    try {
+      existingData = JSON.parse(fs.readFileSync(dataFilePath, 'utf8'));
+    } catch (error) {
+      console.log(`⚠️  Erro ao ler dados existentes para ${year}:`, error.message);
+    }
+  }
+
+  const categories = fs.readdirSync(yearPath)
+    .filter(category => fs.statSync(path.join(yearPath, category)).isDirectory());
+
+  const teamData = {};
+
+  categories.forEach(category => {
+    const categoryPath = path.join(yearPath, category);
+    
+    // Busca apenas imagens que não sejam cartas (aceita .webp e .png)
+    const images = fs.readdirSync(categoryPath)
+      .filter(file => /\.(webp|png)$/i.test(file) && !/_carta\.(webp|png)$/i.test(file))
+      .sort(); // Ordena alfabeticamente
+
+    teamData[category] = images.map(image => {
+      const baseName = image.replace(/\.(webp|png)$/i, '');
+      const memberName = normalizeImageName(image);
+      const imageExtension = image.split('.').pop();
+      const cardImage = baseName + '_carta.' + imageExtension;
+      
+      // Procura dados existentes para preservar LinkedIn
+      let existingLinkedIn = '';
+      if (existingData[category]) {
+        const existingMember = existingData[category].find(member => 
+          member.image === image || member.name === memberName
+        );
+        if (existingMember) {
+          existingLinkedIn = existingMember.linkedin || '';
+        }
+      }
+      
+      return {
+        name: memberName,
+        image: image,
+        cardImage: cardImage,
+        linkedin: existingLinkedIn
+      };
+    });
+
+    console.log(`✅ Categoria "${category}": ${images.length} membros encontrados`);
+  });
+
+  // Salva os dados atualizados
+  fs.writeFileSync(dataFilePath, JSON.stringify(teamData, null, 2));
+  console.log(`🎉 Dados da equipe para ${year} gerados com sucesso!`);
+}
+
+function generateAllTeamData() {
+  console.log('🚀 Iniciando geração de dados da equipe...\n');
+  
+  // Certifica-se de que o diretório data/team existe
+  if (!fs.existsSync(TEAM_DATA_DIR)) {
+    fs.mkdirSync(TEAM_DATA_DIR, { recursive: true });
+    console.log('📁 Diretório data/team criado');
+  }
+
+  // Encontra todos os anos disponíveis
+  const years = fs.readdirSync(TEAM_DIR)
+    .filter(year => {
+      const yearPath = path.join(TEAM_DIR, year);
+      return fs.statSync(yearPath).isDirectory() && /^\d{4}$/.test(year);
+    })
+    .sort();
+
+  if (years.length === 0) {
+    console.log('❌ Nenhum ano encontrado no diretório team');
+    return;
+  }
+
+  console.log(`📅 Anos encontrados: ${years.join(', ')}\n`);
+
+  years.forEach(year => {
+    console.log(`📊 Processando ano ${year}...`);
+    generateTeamDataForYear(year);
+    console.log(''); // Linha em branco para separar anos
+  });
+
+  console.log('✨ Todos os arquivos de dados da equipe foram gerados!');
+  console.log('📝 Lembre-se de adicionar os URLs do LinkedIn manualmente nos arquivos data/team/*.json');
+}
+
+// Função para processar apenas um ano específico
+function generateDataForSpecificYear(year) {
+  console.log(`🚀 Gerando dados para o ano ${year}...\n`);
+  
+  if (!fs.existsSync(TEAM_DATA_DIR)) {
+    fs.mkdirSync(TEAM_DATA_DIR, { recursive: true });
+    console.log('📁 Diretório data/team criado');
+  }
+  
+  generateTeamDataForYear(year);
+}
+
+// Executa o script
+if (process.argv.length > 2) {
+  // Se foi fornecido um ano específico como argumento
+  const year = process.argv[2];
+  if (/^\d{4}$/.test(year)) {
+    generateDataForSpecificYear(year);
+  } else {
+    console.log('❌ Formato de ano inválido. Use: node generateTeamData.js 2024');
+  }
+} else {
+  // Gera dados para todos os anos
+  generateAllTeamData();
+}

--- a/src/components/textContent/team/2022.json
+++ b/src/components/textContent/team/2022.json
@@ -1,0 +1,290 @@
+{
+  "1 - BOARD": [
+    {
+      "name": "Goncalo Jacob",
+      "image": "1 - goncalo_jacob.webp",
+      "cardImage": "1 - goncalo_jacob_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Afonso Cruz",
+      "image": "2 - afonso_cruz.webp",
+      "cardImage": "2 - afonso_cruz_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Carolina Rodrigues",
+      "image": "3 - carolina_rodrigues.webp",
+      "cardImage": "3 - carolina_rodrigues_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "2 - AERODYNAMICS AND COOLING": [
+    {
+      "name": "Simao Goncalves",
+      "image": "1 - simao_goncalves.webp",
+      "cardImage": "1 - simao_goncalves_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Goncalo Martins",
+      "image": "goncalo_martins.webp",
+      "cardImage": "goncalo_martins_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Jose Luciano",
+      "image": "jose_luciano.webp",
+      "cardImage": "jose_luciano_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Mariana Mendonca",
+      "image": "mariana_mendonca.webp",
+      "cardImage": "mariana_mendonca_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Miguel Afonso",
+      "image": "miguel_afonso.webp",
+      "cardImage": "miguel_afonso_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Pedro Lopes",
+      "image": "pedro_lopes.webp",
+      "cardImage": "pedro_lopes_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "3 - DYNAMICS": [
+    {
+      "name": "Afonso Magalhaes",
+      "image": "1 - afonso_magalhaes.webp",
+      "cardImage": "1 - afonso_magalhaes_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Alexandre Lopes",
+      "image": "2 - alexandre_lopes.webp",
+      "cardImage": "2 - alexandre_lopes_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Joao Martins",
+      "image": "2 - joao_martins.webp",
+      "cardImage": "2 - joao_martins_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Guilherme Rodrigues",
+      "image": "guilherme_rodrigues.webp",
+      "cardImage": "guilherme_rodrigues_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Leonor Marques",
+      "image": "leonor_marques.webp",
+      "cardImage": "leonor_marques_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "4 - ELECTRONICS": [
+    {
+      "name": "Pedro Resende",
+      "image": "1 - pedro_resende.webp",
+      "cardImage": "1 - pedro_resende_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Alexandra Leitao",
+      "image": "alexandra_leitao.webp",
+      "cardImage": "alexandra_leitao_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Diogo Luis",
+      "image": "diogo_luis.webp",
+      "cardImage": "diogo_luis_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Diogo Mucharrinha",
+      "image": "diogo_mucharrinha.webp",
+      "cardImage": "diogo_mucharrinha_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Eduardo Montes",
+      "image": "eduardo_montes.webp",
+      "cardImage": "eduardo_montes_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Filipe Marcos",
+      "image": "filipe_marcos.webp",
+      "cardImage": "filipe_marcos_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Miguel Ramos",
+      "image": "miguel_ramos.webp",
+      "cardImage": "miguel_ramos_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "5 - POWERTRAIN": [
+    {
+      "name": "Hugo Ramos",
+      "image": "1 - hugo_ramos.webp",
+      "cardImage": "1 - hugo_ramos_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Francisco Reis",
+      "image": "francisco_reis.webp",
+      "cardImage": "francisco_reis_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "JoãO Reves",
+      "image": "joão_reves.webp",
+      "cardImage": "joão_reves_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Mike De Kanter",
+      "image": "mike_de_kanter.webp",
+      "cardImage": "mike_de_kanter_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "6 - STRUCTURES": [
+    {
+      "name": "Francisco Heitor",
+      "image": "1 - francisco_heitor.webp",
+      "cardImage": "1 - francisco_heitor_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Antonio Vacas",
+      "image": "2 - antonio_vacas.webp",
+      "cardImage": "2 - antonio_vacas_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Tomas Pohle",
+      "image": "2 - tomas_pohle.webp",
+      "cardImage": "2 - tomas_pohle_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Carlos Vasconcelos",
+      "image": "carlos_vasconcelos.webp",
+      "cardImage": "carlos_vasconcelos_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Diogo Lourenco",
+      "image": "diogo_lourenco.webp",
+      "cardImage": "diogo_lourenco_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Duarte Palancha",
+      "image": "duarte_palancha.webp",
+      "cardImage": "duarte_palancha_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Fernao Vieira",
+      "image": "fernao_vieira.webp",
+      "cardImage": "fernao_vieira_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Luis Aser Portela",
+      "image": "luis_aser_portela.webp",
+      "cardImage": "luis_aser_portela_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Nuno Rego",
+      "image": "nuno_rego.webp",
+      "cardImage": "nuno_rego_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Tiago Silva",
+      "image": "tiago_silva.webp",
+      "cardImage": "tiago_silva_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "7 - HUMAN RESOURCES": [
+    {
+      "name": "Carmen Sofia",
+      "image": "1 - carmen_sofia.webp",
+      "cardImage": "1 - carmen_sofia_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "8 - MARKETING AND DESIGN": [
+    {
+      "name": "Isabel Nogueira",
+      "image": "1 - isabel_nogueira.webp",
+      "cardImage": "1 - isabel_nogueira_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Bernardo Silva",
+      "image": "bernardo_silva.webp",
+      "cardImage": "bernardo_silva_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Julia Assuncao",
+      "image": "julia_assuncao.webp",
+      "cardImage": "julia_assuncao_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "9 - MANAGEMENT": [
+    {
+      "name": "Margarida Oliveira",
+      "image": "1 - margarida_oliveira.webp",
+      "cardImage": "1 - margarida_oliveira_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "David Azevedo",
+      "image": "david_azevedo.webp",
+      "cardImage": "david_azevedo_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Joao Romeiro",
+      "image": "joao_romeiro.webp",
+      "cardImage": "joao_romeiro_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Margarida GonçAlves",
+      "image": "margarida_gonçalves.webp",
+      "cardImage": "margarida_gonçalves_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Sofia Seabra",
+      "image": "sofia_seabra.webp",
+      "cardImage": "sofia_seabra_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Tereza Ribeiro",
+      "image": "tereza_ribeiro.webp",
+      "cardImage": "tereza_ribeiro_carta.webp",
+      "linkedin": ""
+    }
+  ]
+}

--- a/src/components/textContent/team/2023.json
+++ b/src/components/textContent/team/2023.json
@@ -1,0 +1,420 @@
+{
+  "AERODYNAMICS AND COOLING": [
+    {
+      "name": "Afonso Sousa",
+      "image": "",
+      "cardImage": "afonso sousa.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Diogo Esculcas",
+      "image": "",
+      "cardImage": "diogo esculcas.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Francisco Pereira",
+      "image": "",
+      "cardImage": "francisco pereira.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Goncalo Lucas",
+      "image": "",
+      "cardImage": "goncalo lucas.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Ines Baptista",
+      "image": "",
+      "cardImage": "ines baptista.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Miguel Afonso",
+      "image": "",
+      "cardImage": "miguel afonso.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Ricardo Rodrigues",
+      "image": "",
+      "cardImage": "ricardo rodrigues.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Vasco Lopes",
+      "image": "",
+      "cardImage": "vasco lopes.png",
+      "linkedin": ""
+    }
+  ],
+  "BOARD": [
+    {
+      "name": "Afonso Magalhaes",
+      "image": "",
+      "cardImage": "afonso_magalhaes.png",
+      "linkedin": ""
+    },
+    {
+      "name": "David Azevedo",
+      "image": "",
+      "cardImage": "david_azevedo.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Hugo Ramos",
+      "image": "",
+      "cardImage": "hugo_ramos.png",
+      "linkedin": ""
+    }
+  ],
+  "DYNAMICS": [
+    {
+      "name": "Afonso Ferreira",
+      "image": "",
+      "cardImage": "afonso_ferreira.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Carolina Carvalho",
+      "image": "",
+      "cardImage": "carolina_carvalho.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Daniel Barata",
+      "image": "",
+      "cardImage": "daniel_barata.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Francisco Miranda",
+      "image": "",
+      "cardImage": "francisco_miranda.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Goncalo Jeronimo",
+      "image": "",
+      "cardImage": "goncalo_jeronimo.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Guilherme Santos",
+      "image": "",
+      "cardImage": "guilherme_santos.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Ines Sousa",
+      "image": "",
+      "cardImage": "ines_sousa.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Mariana Campos",
+      "image": "",
+      "cardImage": "mariana_campos.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Tiago Costa",
+      "image": "",
+      "cardImage": "tiago_costa.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Tomas Castro",
+      "image": "",
+      "cardImage": "tomas_castro.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Vera Carvalho",
+      "image": "",
+      "cardImage": "vera_carvalho.png",
+      "linkedin": ""
+    }
+  ],
+  "ELECTRONICS": [
+    {
+      "name": "Antonio Mangueira",
+      "image": "",
+      "cardImage": "antonio_mangueira.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Francisco Dias",
+      "image": "",
+      "cardImage": "francisco_dias.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Hugo Brites",
+      "image": "",
+      "cardImage": "hugo_brites.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Joao Reis",
+      "image": "",
+      "cardImage": "joao_reis.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Tiago Costa",
+      "image": "",
+      "cardImage": "tiago_costa.png",
+      "linkedin": ""
+    }
+  ],
+  "HUMAN RESOURCES": [
+    {
+      "name": "Beatriz Marcalo",
+      "image": "",
+      "cardImage": "beatriz_marcalo.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Constanca Brito",
+      "image": "",
+      "cardImage": "constanca_brito.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Ines Nunes",
+      "image": "",
+      "cardImage": "ines_nunes.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Margarida Goncalves",
+      "image": "",
+      "cardImage": "margarida_goncalves.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Maria Rita Lopes",
+      "image": "",
+      "cardImage": "maria_rita_lopes.png",
+      "linkedin": ""
+    }
+  ],
+  "LOGISTICS": [
+    {
+      "name": "Carlota Le",
+      "image": "",
+      "cardImage": "carlota_le.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Francisco Simoes",
+      "image": "",
+      "cardImage": "francisco_simoes.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Sofia Gil",
+      "image": "",
+      "cardImage": "sofia_gil.png",
+      "linkedin": ""
+    }
+  ],
+  "MANAGEMENT": [
+    {
+      "name": "Madalena Figueirinhas",
+      "image": "",
+      "cardImage": "madalena_figueirinhas.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Margarida Goncalves",
+      "image": "",
+      "cardImage": "margarida_goncalves.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Tiago Val",
+      "image": "",
+      "cardImage": "tiago_val.png",
+      "linkedin": ""
+    }
+  ],
+  "MARKETING AND DESIGN": [
+    {
+      "name": "Bernardo Silva",
+      "image": "",
+      "cardImage": "bernardo_silva.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Catarina Couquinha",
+      "image": "",
+      "cardImage": "catarina_couquinha.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Constanca Florindo",
+      "image": "",
+      "cardImage": "constanca_florindo.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Dinis Felgueiras",
+      "image": "",
+      "cardImage": "dinis_felgueiras.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Estela Leandro",
+      "image": "",
+      "cardImage": "estela_leandro.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Rita Pulido",
+      "image": "",
+      "cardImage": "rita_pulido.png",
+      "linkedin": ""
+    }
+  ],
+  "POWERTRAIN": [
+    {
+      "name": "Francisco Reis",
+      "image": "",
+      "cardImage": "Francisco reis.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Hugo Teixeira",
+      "image": "",
+      "cardImage": "Hugo teixeira.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Daniel Serrano",
+      "image": "",
+      "cardImage": "daniel serrano.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Joao Reves",
+      "image": "",
+      "cardImage": "joao reves.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Matilde Sardinha",
+      "image": "",
+      "cardImage": "matilde sardinha.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Tomas Gloria",
+      "image": "",
+      "cardImage": "tomas gloria.png",
+      "linkedin": ""
+    }
+  ],
+  "SPONSORS": [
+    {
+      "name": "Afonso Silva",
+      "image": "",
+      "cardImage": "afonso_silva.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Andre Marques",
+      "image": "",
+      "cardImage": "andre_marques.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Leonor Tavares",
+      "image": "",
+      "cardImage": "leonor_tavares.png",
+      "linkedin": ""
+    }
+  ],
+  "STRUCTURES": [
+    {
+      "name": "Andre Rodrigues",
+      "image": "",
+      "cardImage": "andre_rodrigues.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Armenio Correia",
+      "image": "",
+      "cardImage": "armenio_correia.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Catarina Faria",
+      "image": "",
+      "cardImage": "catarina_faria.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Duarte Ferreira",
+      "image": "",
+      "cardImage": "duarte_ferreira.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Duarte Palancha",
+      "image": "",
+      "cardImage": "duarte_palancha.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Francisco Abrantes",
+      "image": "",
+      "cardImage": "francisco_abrantes.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Joao Poupado",
+      "image": "",
+      "cardImage": "joao_poupado.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Jose Cadete",
+      "image": "",
+      "cardImage": "jose_cadete.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Lourenco Melo",
+      "image": "",
+      "cardImage": "lourenco_melo.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Nuno Rego",
+      "image": "",
+      "cardImage": "nuno_rego.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Nuno Rodrigues",
+      "image": "",
+      "cardImage": "nuno_rodrigues.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Raquel Santos",
+      "image": "",
+      "cardImage": "raquel_santos.png",
+      "linkedin": ""
+    },
+    {
+      "name": "Tiago Silva",
+      "image": "",
+      "cardImage": "tiago_silva.png",
+      "linkedin": ""
+    }
+  ]
+}

--- a/src/components/textContent/team/2024.json
+++ b/src/components/textContent/team/2024.json
@@ -1,0 +1,278 @@
+{
+  "1 - BOARD": [
+    {
+      "name": "Vasco Lopes",
+      "image": "1 - vasco_lopes.webp",
+      "cardImage": "1 - vasco_lopes_carta.webp",
+      "linkedin": "https://www.linkedin.com/in/vasco-lopes-example/"
+    },
+    {
+      "name": "Hugo Teixeira",
+      "image": "hugo_teixeira.webp",
+      "cardImage": "hugo_teixeira_carta.webp",
+      "linkedin": "https://www.linkedin.com/in/hugo-teixeira-example/"
+    },
+    {
+      "name": "Nadia Pires",
+      "image": "nadia_pires.webp",
+      "cardImage": "nadia_pires_carta.webp",
+      "linkedin": "https://www.linkedin.com/in/nadia-pires-example/"
+    }
+  ],
+  "AERODYNAMICS AND COOLING": [
+    {
+      "name": "Ines Baptista",
+      "image": "1 - ines_baptista.webp",
+      "cardImage": "1 - ines_baptista_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Helena Ribeiro",
+      "image": "2 - helena_ribeiro.webp",
+      "cardImage": "2 - helena_ribeiro_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Artur Cunha",
+      "image": "artur_cunha.webp",
+      "cardImage": "artur_cunha_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Bernardo Silva",
+      "image": "bernardo_silva.webp",
+      "cardImage": "bernardo_silva_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Eduardo Perdigao",
+      "image": "eduardo_perdigao.webp",
+      "cardImage": "eduardo_perdigao_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Francisco Brazao",
+      "image": "francisco_brazao.webp",
+      "cardImage": "francisco_brazao_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Miguel Carvalho",
+      "image": "miguel_carvalho.webp",
+      "cardImage": "miguel_carvalho_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "DYNAMICS": [
+    {
+      "name": "Francisco Miranda",
+      "image": "1 - francisco_miranda.webp",
+      "cardImage": "1 - francisco_miranda_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Diogo Dias",
+      "image": "2 - diogo_dias.webp",
+      "cardImage": "2 - diogo_dias_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Tiago Costa",
+      "image": "3 - tiago_costa.webp",
+      "cardImage": "3 - tiago_costa_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Afonso Gaminha",
+      "image": "afonso_gaminha.webp",
+      "cardImage": "afonso_gaminha_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Carolina Dias",
+      "image": "carolina_dias.webp",
+      "cardImage": "carolina_dias_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Constanca Simoes",
+      "image": "constanca_simoes.webp",
+      "cardImage": "constanca_simoes_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Daniel Barata",
+      "image": "daniel_barata.webp",
+      "cardImage": "daniel_barata_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Tiago Cilinio",
+      "image": "tiago_cilinio.webp",
+      "cardImage": "tiago_cilinio_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "ELECTRONICS": [
+    {
+      "name": "Pedro Afonso",
+      "image": "1 - pedro_afonso.webp",
+      "cardImage": "1 - pedro_afonso_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Francisco Alves",
+      "image": "2 - francisco_alves.webp",
+      "cardImage": "2 - francisco_alves_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Hugo Carlos",
+      "image": "3 - hugo_carlos.webp",
+      "cardImage": "3 - hugo_carlos_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Antonio Mangueira",
+      "image": "antonio_mangueira.webp",
+      "cardImage": "antonio_mangueira_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Sofia Mendes",
+      "image": "sofia_mendes.webp",
+      "cardImage": "sofia_mendes_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "HUMAN RESOURCES": [
+    {
+      "name": "Ines Nunes",
+      "image": "1 - ines_nunes.webp",
+      "cardImage": "1 - ines_nunes_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Mafalda Santo",
+      "image": "mafalda_santo.webp",
+      "cardImage": "mafalda_santo_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Mariana Oliveira",
+      "image": "mariana_oliveira.webp",
+      "cardImage": "mariana_oliveira_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "MANAGEMENT": [
+    {
+      "name": "Constanca Brito",
+      "image": "constanca_brito.webp",
+      "cardImage": "constanca_brito_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "MARKETING AND DESIGN": [
+    {
+      "name": "Rita Pulido",
+      "image": "1 - rita_pulido.webp",
+      "cardImage": "1 - rita_pulido_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Joao Santos",
+      "image": "joao_santos.webp",
+      "cardImage": "joao_santos_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Ricardo Martins",
+      "image": "ricardo_martins.webp",
+      "cardImage": "ricardo_martins_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "POWERTRAIN": [
+    {
+      "name": "Gustavo Girbal",
+      "image": "1 - gustavo_girbal.webp",
+      "cardImage": "1 - gustavo_girbal_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Afonso Araujo",
+      "image": "afonso_araujo.webp",
+      "cardImage": "afonso_araujo_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Eduardo Martins",
+      "image": "eduardo_martins.webp",
+      "cardImage": "eduardo_martins_carta.webp",
+      "linkedin": ""
+    }
+  ],
+  "STRUCTURES": [
+    {
+      "name": "Pedro Neves",
+      "image": "1 - pedro_neves.webp",
+      "cardImage": "1 - pedro_neves_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Miguel Goncalves",
+      "image": "2 - miguel_goncalves.webp",
+      "cardImage": "2 - miguel_goncalves_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Afonso Monteiro",
+      "image": "afonso_monteiro.webp",
+      "cardImage": "afonso_monteiro_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Afonso Vieira",
+      "image": "afonso_vieira.webp",
+      "cardImage": "afonso_vieira_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Carlos Moco",
+      "image": "carlos_moco.webp",
+      "cardImage": "carlos_moco_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Catarina Sa",
+      "image": "catarina_sa.webp",
+      "cardImage": "catarina_sa_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Francisco Abrantes",
+      "image": "francisco_abrantes.webp",
+      "cardImage": "francisco_abrantes_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Gustavo Curado",
+      "image": "gustavo_curado.webp",
+      "cardImage": "gustavo_curado_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Luis Goncalves",
+      "image": "luis_goncalves.webp",
+      "cardImage": "luis_goncalves_carta.webp",
+      "linkedin": ""
+    },
+    {
+      "name": "Martim Silva",
+      "image": "martim_silva.webp",
+      "cardImage": "martim_silva_carta.webp",
+      "linkedin": ""
+    }
+  ]
+}

--- a/src/components/utils/FetchFolderImages.tsx
+++ b/src/components/utils/FetchFolderImages.tsx
@@ -1,6 +1,76 @@
 import fs from "fs";
 import path from "path";
 
+const TEAM_DIR = path.join(process.cwd(), "public/images/team");
+const TEAM_DATA_DIR = path.join(process.cwd(), "src/components/textContent/team");
+
+export function getAvailableYears() {
+  return fs
+    .readdirSync(TEAM_DIR, { encoding: "utf8" }) // Ensure UTF-8 encoding
+    .filter(
+      year =>
+        fs.statSync(path.join(TEAM_DIR, year)).isDirectory() &&
+        /^\d{4}$/.test(year) &&
+        year !== "2023"
+    )
+    .sort((a, b) => parseInt(b) - parseInt(a));
+}
+
+export function getTeamMembersWithLinkedIn(year: string) {
+  const yearPath = path.join(TEAM_DIR, year);
+  const teamDataPath = path.join(TEAM_DATA_DIR, `${year}.json`);
+
+  if (!fs.existsSync(yearPath)) return { data: [], team: "" };
+
+  const pathpics = fs
+    .readdirSync(yearPath, { encoding: "utf8" })
+    .filter(file => /\.(webp|png)$/i.test(file));
+
+  let teampic = "";
+  if (pathpics.length > 0)
+    teampic = `/images/team/${year}/${encodeURIComponent(pathpics[0].normalize("NFC"))}`;
+
+  let teamData: Record<
+    string,
+    Array<{ name: string; image: string; cardImage: string; linkedin?: string | null }>
+  > = {};
+  if (fs.existsSync(teamDataPath)) {
+    try {
+      const rawData = fs.readFileSync(teamDataPath, "utf8");
+      teamData = JSON.parse(rawData);
+    } catch (error) {
+      console.error(`Error reading team data for ${year}:`, error);
+    }
+  }
+
+  const data = Object.keys(teamData)
+    .map(category => {
+      const categoryName = category.normalize("NFC").replace(/^\d+ -\s*/, "");
+      const membersData = teamData[category] || [];
+
+      const members = membersData
+        .filter((member: { image: string }) => member.image && member.image !== "")
+        .map(member => ({
+          name: member.name,
+          image: `/images/team/${year}/${encodeURIComponent(category.normalize("NFC"))}/${encodeURIComponent(member.image)}`,
+          cardImage: `/images/team/${year}/${encodeURIComponent(category.normalize("NFC"))}/${encodeURIComponent(member.cardImage)}`,
+          linkedin: member.linkedin || null,
+        }));
+
+      return {
+        name: categoryName,
+        members: members,
+        images: members.map((member: { image: string }) => member.image),
+      };
+    })
+    .filter(category => category.members.length > 0);
+
+  return {
+    data: data,
+    team: teampic,
+  };
+}
+
 const PUBLIC_DIR = path.join(process.cwd(), "public");
 export function getImages(folderPath: string): string[] {
   const absPath = path.join(PUBLIC_DIR, folderPath);

--- a/src/pages/team/[year].tsx
+++ b/src/pages/team/[year].tsx
@@ -1,14 +1,16 @@
+import React from "react";
 import Image from "next/image";
 import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
-import { getTeamImages, getAvailableYears } from "../../components/utils/FetchFolderImages";
+import {
+  getTeamMembersWithLinkedIn,
+  getAvailableYears,
+} from "../../components/utils/FetchFolderImages";
 import MyDefaultPage from "../../components/DefaultPage";
-//import styles from '@/styles/Team.module.scss';
-//import defaultPage from '@/styles/DefaultPage.module.scss';
 
-export async function getStaticProps({ params }) {
+export async function getStaticProps({ params }: { params: { year: string } }) {
   const { year } = params;
-  const teamData = getTeamImages(year);
+  const teamData = getTeamMembersWithLinkedIn(year);
 
   return { props: { teamData, year } };
 }
@@ -16,102 +18,213 @@ export async function getStaticProps({ params }) {
 export async function getStaticPaths() {
   const years = getAvailableYears();
 
-  const paths = years.map(year => ({
+  const paths = years.map((year: string) => ({
     params: { year },
   }));
 
   return { paths, fallback: false };
 }
 
-export default function Team({ teamData, year }) {
+interface TeamMember {
+  name: string;
+  image: string;
+  cardImage: string;
+  linkedin?: string;
+}
+
+interface TeamCategory {
+  name: string;
+  members: TeamMember[];
+}
+
+interface TeamData {
+  data: TeamCategory[];
+  team: string;
+}
+
+interface TeamProps {
+  teamData: TeamData;
+  year: string;
+}
+
+export default function Team({ teamData, year }: TeamProps) {
   const router = useRouter();
-  const [focusedImage, setFocusedImage] = useState(null);
-  const [focusedCardImage, setFocusedCardImage] = useState(null);
+  const [focusedImage, setFocusedImage] = useState<string | null>(null);
+  const [focusedCardImage, setFocusedCardImage] = useState<string | null>(null);
+  const [focusedMember, setFocusedMember] = useState<TeamMember | null>(null);
+  const [mobilePopupOpen, setMobilePopupOpen] = useState(false);
 
-  const MIN_TEAM_YEAR = 2022;
-  const MAX_TEAM_YEAR = 2024;
-
+  const AVAILABLE_YEARS = [2022, 2024]; // Anos disponíveis (excluindo 2023)
   const currentYear = parseInt(year, 10);
+  const currentIndex = AVAILABLE_YEARS.indexOf(currentYear);
 
-  const handleYearChange = direction => {
-    const newYear = direction === "next" ? currentYear + 1 : currentYear - 1;
-    return router.push(`/team/${newYear}`);
+  const handleYearChange = (direction: "prev" | "next") => {
+    const newIndex = direction === "next" ? currentIndex + 1 : currentIndex - 1;
+
+    if (newIndex >= 0 && newIndex < AVAILABLE_YEARS.length) {
+      const newYear = AVAILABLE_YEARS[newIndex];
+      return router.push(`/team/${newYear}`);
+    }
   };
 
   useEffect(() => {
     setFocusedCardImage(teamData.team);
+    setMobilePopupOpen(true);
   }, [teamData]);
-  /* <div className={defaultPage.container}>
-      <div className={defaultPage.background}></div>
-      <div className={defaultPage.row}>
-        <button
-          onClick={() => handleYearChange('prev')}
-          className={`${styles.yearButton} ${currentYear <= MIN_TEAM_YEAR ? styles.hiddenButton : ''}`}
-        >
-          {'<'}
-        </button>
-
-        <h1 className={defaultPage.title}>
-          <span className={defaultPage.white}>{'Team '}</span>
-          <span className={defaultPage.blue}>{year}</span>
-        </h1>
-
-        <button
-          onClick={() => handleYearChange('next')}
-          className={`${styles.yearButton} ${currentYear >= MAX_TEAM_YEAR ? styles.hiddenButton : ''}`}
-        >
-          {'>'}
-        </button>
-      </div>
-
-      <div className={styles.sidetoside}>
-        <div>
-          {teamData.data.length === 0 ? (
-            <p>No data available for {year}</p>
-          ) : (
-            teamData.data.map(({ name, images }) => (
-              <div key={name} className={styles.teamSection}>
-                <div className={styles.area}>
-                  <img src="/images/team/raio.webp" alt="Team Icon" className={styles.teamIcon} />
-                  <h2>{name}</h2>
-                </div>
-                <div className={defaultPage.imageGrid}>
-                  {images.map(image => (
-                    <Image
-                      key={image}
-                      src={image}
-                      alt={name}
-                      width={125}
-                      height={125}
-                      loading="lazy" // Enable lazy loading
-                      className={`${styles.teamImage} ${focusedImage === image ? styles.focused : ''}`}
-                      onClick={() => {
-                        setFocusedImage(image);
-                        setFocusedCardImage(image.slice(0, -5) + '_carta.webp');
-                      }}
-                    />
-                  ))}
-                </div>
-              </div>
-            ))
-          )}
-        </div>
-
-        {focusedCardImage && (
-          <Image
-            src={focusedCardImage}
-            alt="Focused Image"
-            width={300}
-            height={400}
-            loading="lazy"
-            className={styles.mainImage}
-          />
-        )}
-      </div>
-    </div> */
   return (
     <MyDefaultPage>
-      <div></div>
+      <div className="relative min-h-screen pt-24">
+        <div className="flex items-center justify-center py-8">
+          <button
+            onClick={() => handleYearChange("prev")}
+            className={`px-4 py-2 text-white text-5xl font-semibold uppercase transition-all duration-300 hover:scale-105 hover:shadow-lg ${
+              currentIndex <= 0 ? "invisible" : ""
+            }`}
+          >
+            {"<"}
+          </button>
+
+          <h1 className="mx-4 sm:mx-8 text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold uppercase tracking-wider">
+            <span className="text-white">Team </span>
+            <span className="text-blue-500">{year}</span>
+          </h1>
+
+          <button
+            onClick={() => handleYearChange("next")}
+            className={`px-4 py-2 text-white text-5xl font-semibold uppercase transition-all duration-300 hover:scale-105 hover:shadow-lg ${
+              currentIndex >= AVAILABLE_YEARS.length - 1 ? "invisible" : ""
+            }`}
+          >
+            {">"}
+          </button>
+        </div>
+
+        <div className="relative flex mt-8">
+          <div className="w-full lg:max-w-[57.5%] pl-8 sm:pl-12 md:pl-16">
+            {teamData.data.length === 0 ? (
+              <p className="text-white text-center">No data available for {year}</p>
+            ) : (
+              teamData.data.map(({ name, members }) => (
+                <div key={name} className="mb-20">
+                  <div className="flex items-center pl-6 rounded-xl transition-all duration-300 -mt-12">
+                    <Image
+                      src="/images/team/raio.webp"
+                      alt="Team Icon"
+                      width={40}
+                      height={40}
+                      className="w-10 h-10 mr-4 object-contain -translate-y-2"
+                    />
+                    <h2 className="text-white text-2xl font-bold uppercase tracking-[2.5px] mb-4">
+                      {name}
+                    </h2>
+                  </div>
+
+                  <div className="flex flex-wrap gap-1 sm:gap-2 md:gap-3 lg:gap-4 mt-2">
+                    {members.map((member, index) => (
+                      <div
+                        key={`${member.image}-${index}`}
+                        className="text-center flex-shrink-0"
+                        style={{
+                          width: "clamp(80px, 12vw, 120px)",
+                        }}
+                      >
+                        <Image
+                          src={member.image}
+                          alt={member.name}
+                          width={125}
+                          height={125}
+                          loading="lazy"
+                          className={`cursor-pointer transition-all duration-300 rounded-2xl hover:scale-105 w-full aspect-square object-cover ${
+                            focusedImage === member.image ? "border-4 border-red-800" : ""
+                          }`}
+                          onClick={() => {
+                            setFocusedImage(member.image);
+                            setFocusedCardImage(member.cardImage);
+                            setFocusedMember(member);
+                            setMobilePopupOpen(true);
+                          }}
+                        />
+                        <div className="mt-3 text-center">
+                          <p className="text-white text-xs sm:text-sm font-medium mb-1 truncate">
+                            {member.name}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+          {focusedCardImage && (
+            <>
+              <div className="hidden lg:flex fixed left-[65%] bottom-[10%] flex-col items-center z-10">
+                <Image
+                  src={focusedCardImage}
+                  alt="Focused Image"
+                  width={250}
+                  height={330}
+                  loading="lazy"
+                  className="border-4 border-black h-[50vh] shadow-[0_0_30px_10px_rgba(6,90,123,1)]"
+                />
+                <div className="mt-4 text-center h-12 flex items-center justify-center">
+                  {focusedMember && focusedMember.linkedin ? (
+                    <a
+                      href={focusedMember.linkedin}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-block px-6 py-3 bg-[#0077b5] text-white font-semibold rounded-lg transition-all duration-300 hover:bg-[#005885] hover:-translate-y-0.5 hover:shadow-lg hover:shadow-[rgba(0,119,181,0.3)]"
+                    >
+                      LinkedIn
+                    </a>
+                  ) : null}
+                </div>
+              </div>
+              {mobilePopupOpen && focusedCardImage && (
+                <div className="lg:hidden fixed inset-0 backdrop-blur-lg bg-black/30 flex items-center justify-center z-50 p-4">
+                  <div className="relative flex flex-col items-center">
+                    <Image
+                      src={focusedCardImage}
+                      alt="Focused Image"
+                      width={220}
+                      height={280}
+                      loading="lazy"
+                      className="w-full h-auto max-h-[45vh] max-w-[70vw] object-contain"
+                    />
+
+                    <div
+                      className={`flex w-full mt-3 px-2 ${
+                        focusedMember ? "justify-between" : "justify-center"
+                      }`}
+                    >
+                      <button
+                        onClick={() => {
+                          setFocusedImage(null);
+                          setFocusedMember(null);
+                          setMobilePopupOpen(false);
+                        }}
+                        className="px-4 py-2 bg-gray-600 text-white font-medium text-sm rounded-lg transition-all duration-300 hover:bg-gray-500"
+                      >
+                        Close
+                      </button>
+                      {focusedMember && focusedMember.linkedin && (
+                        <a
+                          href={focusedMember.linkedin}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="px-4 py-2 bg-[#0077b5] text-white font-medium text-sm rounded-lg transition-all duration-300 hover:bg-[#005885]"
+                        >
+                          LinkedIn
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
     </MyDefaultPage>
   );
 }

--- a/src/pages/team/index.tsx
+++ b/src/pages/team/index.tsx
@@ -1,24 +1,26 @@
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { getAvailableYears } from "../../components/utils/FetchFolderImages";
-// import { redirect } from 'next/navigation'; ver se é possivel usar redirect
 
 export async function getStaticProps() {
-  const years = getAvailableYears(); // Ensure this works without async if using static export
-
+  const years = await getAvailableYears(); 
   return {
     props: { years },
   };
 }
 
-export default function TeamIndex({ years }) {
+interface TeamIndexProps {
+  years: string[];
+}
+
+export default function TeamIndex({ years }: TeamIndexProps) {
   const router = useRouter();
 
   useEffect(() => {
     if (years.length > 0) {
-      router.replace(`/team/${years[0]}`); // Redirect to the latest year
+      router.replace(`/team/${years[0]}`); 
     }
   }, [years, router]);
 
-  return;
+  return null;
 }


### PR DESCRIPTION
- Created JSON files for team members for the years 2022, 2023, and 2024.
- Updated FetchFolderImages utility to include LinkedIn URLs for team members.
- Modified team page to display LinkedIn links and handle year navigation.
- Implemented responsive design for team member images and popups.
- Adjusted routing to redirect to the latest team year on index page.